### PR TITLE
fix: delete dead code WsNotifyPlayerLeftLobbyHandler

### DIFF
--- a/src/common/usecase/events/UseCaseEvent.ts
+++ b/src/common/usecase/events/UseCaseEvent.ts
@@ -5,4 +5,4 @@ import { DomainEvent } from '#common/domain/events/DomainEvent';
  * Use case events are produced by the outbox-to-eventbus pipeline.
  * Each concrete event carries its own typed aggregate identifier (e.g. lobbyId).
  */
-export interface UseCaseEvent extends DomainEvent {}
+export type UseCaseEvent = DomainEvent;

--- a/src/matchmaking/infrastructure/handlers/WsNotifyPlayerLeftLobbyHandler.ts
+++ b/src/matchmaking/infrastructure/handlers/WsNotifyPlayerLeftLobbyHandler.ts
@@ -1,8 +1,0 @@
-import { EventHandler } from '#common/usecase/EventHandler';
-import { PlayerLeftLobbyUseCaseEvent } from '#matchmaking/usecase/events/PlayerLeftLobbyUseCaseEvent';
-
-export class WsNotifyPlayerLeftLobbyHandler implements EventHandler<PlayerLeftLobbyUseCaseEvent> {
-    handle(event: PlayerLeftLobbyUseCaseEvent): void {
-        console.log(`Player ${event.playerId.value} left lobby`);
-    }
-}


### PR DESCRIPTION
## Summary
- Delete dead code file `WsNotifyPlayerLeftLobbyHandler.ts` (no references in codebase)
- Fix empty interface lint error in `UseCaseEvent.ts` (changed to type alias)

## Comment addressed
> WsNotifyPlayerLeftLobbyHandler is dead code — commit history shows it was supposedly deleted but is still present

This PR addresses a review comment on PR #40