### PR TITLE
fix: parameterize EventBus and EventHandler with UseCaseEvent instead of DomainEvent (PR #40 review)

### DIFF
--- a/src/common/usecase/EventBus.ts
+++ b/src/common/usecase/EventBus.ts
@@ -1,7 +1,7 @@
-import { DomainEvent } from '#common/domain/events/DomainEvent';
+import { UseCaseEvent } from '#common/usecase/events/UseCaseEvent';
 import { EventHandler } from './EventHandler';
 
 export interface EventBus {
-    publish<T extends DomainEvent>(event: T): void;
-    register<T extends DomainEvent>(eventType: string, handler: EventHandler<T>): void;
+    publish<T extends UseCaseEvent>(event: T): void;
+    register<T extends UseCaseEvent>(eventType: string, handler: EventHandler<T>): void;
 }

--- a/src/common/usecase/EventHandler.ts
+++ b/src/common/usecase/EventHandler.ts
@@ -1,5 +1,5 @@
-import { DomainEvent } from '#common/domain/events/DomainEvent';
+import { UseCaseEvent } from '#common/usecase/events/UseCaseEvent';
 
-export interface EventHandler<T extends DomainEvent> {
+export interface EventHandler<T extends UseCaseEvent> {
     handle(event: T): void;
 }

--- a/src/common/usecase/events/UseCaseEvent.ts
+++ b/src/common/usecase/events/UseCaseEvent.ts
@@ -5,4 +5,5 @@ import { DomainEvent } from '#common/domain/events/DomainEvent';
  * Use case events are produced by the outbox-to-eventbus pipeline.
  * Each concrete event carries its own typed aggregate identifier (e.g. lobbyId).
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UseCaseEvent extends DomainEvent {}

--- a/src/matchmaking/infrastructure/event-bus/InMemoryEventBus.ts
+++ b/src/matchmaking/infrastructure/event-bus/InMemoryEventBus.ts
@@ -1,17 +1,17 @@
-import { DomainEvent } from '#common/domain/events/DomainEvent';
+import { UseCaseEvent } from '#common/usecase/events/UseCaseEvent';
 import { EventBus } from '#common/usecase/EventBus';
 import { EventHandler } from '#common/usecase/EventHandler';
 
 export class InMemoryEventBus implements EventBus {
-    private handlers = new Map<string, EventHandler<DomainEvent>[]>();
+    private handlers = new Map<string, EventHandler<UseCaseEvent>[]>();
 
-    publish<T extends DomainEvent>(event: T): void {
+    publish<T extends UseCaseEvent>(event: T): void {
         const eventHandlers = this.handlers.get(event.type);
 
         eventHandlers?.forEach((handler) => handler.handle(event));
     }
 
-    register<T extends DomainEvent>(eventType: string, handler: EventHandler<T>): void {
+    register<T extends UseCaseEvent>(eventType: string, handler: EventHandler<T>): void {
         const current = this.handlers.get(eventType) ?? [];
         this.handlers.set(eventType, [...current, handler]);
     }

--- a/test/matchmaking/infastructure/processors/OutboxProcessor.test.ts
+++ b/test/matchmaking/infastructure/processors/OutboxProcessor.test.ts
@@ -4,7 +4,7 @@ import { OutboxMessageMother } from '#test/matchmaking/domain/outbox/OutboxMessa
 import { InMemoryOutboxRepository } from '#matchmaking/infrastructure/db/inMemory/outbox/InMemoryOutboxRepository';
 import { PlayerJoinedLobbyUseCaseEvent } from '#matchmaking/usecase/events/PlayerJoinedLobbyUseCaseEvent';
 import { PlayerLeftLobbyUseCaseEvent } from '#matchmaking/usecase/events/PlayerLeftLobbyUseCaseEvent';
-import { DomainEvent } from '#common/domain/events/DomainEvent';
+import { UseCaseEvent } from '#common/usecase/events/UseCaseEvent';
 
 const EventBusMock = vi.fn(
     class {
@@ -84,7 +84,7 @@ describe('OutboxProcessor', () => {
                 const message1 = OutboxMessageMother.playerJoined('lobby-1');
                 const message2 = OutboxMessageMother.playerLeft('lobby-2');
                 const message3 = OutboxMessageMother.playerJoined('lobby-3');
-                mockEventBus.publish.mockImplementationOnce((event: DomainEvent) => {
+                mockEventBus.publish.mockImplementationOnce((event: UseCaseEvent) => {
                     if (event.type === message2.eventType) {
                         throw new Error('Processing failed for message 2');
                     }


### PR DESCRIPTION
## Summary
- Change `EventBus.publish()` and `EventBus.register()` generic constraints from `DomainEvent` to `UseCaseEvent`
- Change `EventHandler<T>` generic constraint from `DomainEvent` to `UseCaseEvent`
- Update `InMemoryEventBus` implementation to match
- Add `eslint-disable` comment for pre-existing empty-interface lint warning on `UseCaseEvent`

## Comment addressed
> `EventBus` accepts `DomainEvent`, not `UseCaseEvent` — `src/common/usecase/EventBus.ts:5` and `EventHandler.ts:3` are parameterized with `DomainEvent`, undermining the separation this PR introduces.
>
> — @opencode-agent[bot] on issue comment (PR #40)

This PR addresses a review comment on PR #40