### PR TITLE
fix: rename misleading test at OutboxProcessor.test.ts:100 (PR #40 review)

### DIFF
--- a/test/matchmaking/infastructure/processors/OutboxProcessor.test.ts
+++ b/test/matchmaking/infastructure/processors/OutboxProcessor.test.ts
@@ -97,7 +97,7 @@ describe('OutboxProcessor', () => {
                 expect(mockEventBus.publish).toHaveBeenCalledTimes(3);
             });
 
-            it('does not process the same message again after an error', () => {
+            it('continues processing subsequent messages after an error', () => {
                 const message1 = OutboxMessageMother.playerJoined('lobby-1');
                 const message2 = OutboxMessageMother.playerLeft('lobby-2');
                 mockEventBus.publish.mockImplementationOnce(() => {


### PR DESCRIPTION
## Summary
- Rename misleading test description to accurately reflect its behavior

## Comment addressed
> "Test at `OutboxProcessor.test.ts:100` has misleading name — The it-block says 'does not process the same message again after an error' but actually tests that new messages continue processing after a failure."
>
> — @opencode-agent[bot] on `test/matchmaking/infastructure/processors/OutboxProcessor.test.ts:100` (PR #40)

This PR addresses a review comment on PR #40