### PR TITLE
fix: delete dead WsNotifyPlayerLeftLobbyHandler (PR #40 review)

### DIFF
--- a/src/matchmaking/infrastructure/handlers/WsNotifyPlayerLeftLobbyHandler.ts
+++ b/src/matchmaking/infrastructure/handlers/WsNotifyPlayerLeftLobbyHandler.ts
@@ -1,8 +1,0 @@
-import { EventHandler } from '#common/usecase/EventHandler';
-import { PlayerLeftLobbyUseCaseEvent } from '#matchmaking/usecase/events/PlayerLeftLobbyUseCaseEvent';
-
-export class WsNotifyPlayerLeftLobbyHandler implements EventHandler<PlayerLeftLobbyUseCaseEvent> {
-    handle(event: PlayerLeftLobbyUseCaseEvent): void {
-        console.log(`Player ${event.playerId.value} left lobby`);
-    }
-}


### PR DESCRIPTION
## Summary
- [Fixes @opencode-agent[bot]'s review](https://github.com/arompr/pioneer-api/pull/40#issuecomment-4583611123): dead WsNotifyPlayerLeftLobbyHandler not wired anywhere

## Comment addressed
> `WsNotifyPlayerLeftLobbyHandler` is dead code — commit history shows it was supposedly deleted but is still present
>
> — @opencode-agent[bot] on [PR #40](https://github.com/arompr/pioneer-api/pull/40#issuecomment-4583611123)

This PR addresses a review comment on PR #40